### PR TITLE
ci: simplify release workflow and update documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,10 @@ jobs:
       - name: Run tests
         run: uv run pytest tests/ -v
 
-  build-and-publish:
+  release:
     runs-on: ubuntu-latest
     needs: test
-    environment: pypi
     permissions:
-      id-token: write
       contents: write
 
     steps:
@@ -47,9 +45,6 @@ jobs:
 
       - name: Build package
         run: uv build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pre-commit-check-git-user
 
 [![CI](https://github.com/grigoriev/pre-commit-check-git-user/actions/workflows/python-package.yml/badge.svg)](https://github.com/grigoriev/pre-commit-check-git-user/actions/workflows/python-package.yml)
-[![PyPI version](https://badge.fury.io/py/pre-commit-check-git-user.svg)](https://badge.fury.io/py/pre-commit-check-git-user)
+[![GitHub Release](https://img.shields.io/github/v/release/grigoriev/pre-commit-check-git-user)](https://github.com/grigoriev/pre-commit-check-git-user/releases)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ ignore = []
 [tool.ruff.lint.isort]
 known-first-party = ["pre_commit_hooks"]
 
+[tool.uv]
+required-version = ">=0.5.0"
+
 [tool.coverage.run]
 source = ["pre_commit_hooks"]
 branch = true


### PR DESCRIPTION
- Renamed job `build-and-publish` to `release` for clarity.
- Removed PyPI publishing step from workflow.
- Added `required-version` field to `pyproject.toml`.
- Updated badge in `README.md` to reflect GitHub releases.