### PR TITLE
chore: enable dependency dashboard explicitly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "dependencyDashboard": true,
   "automerge": true,
   "automergeType": "branch",
   "platformAutomerge": false


### PR DESCRIPTION
Enable `dependencyDashboard: true` to ensure Dashboard is updated even in silent mode.