### PR TITLE
fix: disable Renovate dependency dashboard approval requirement

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended"
   ],
   "dependencyDashboard": true,
+  "dependencyDashboardApproval": false,
   "automerge": true,
   "automergeType": "branch",
   "platformAutomerge": false


### PR DESCRIPTION
## Summary
- Explicitly set `dependencyDashboardApproval: false` in Renovate config
- `config:recommended` preset requires manual approval via dashboard checkboxes, which was preventing automatic PR creation

## Test plan
- [ ] Verify Renovate creates PRs automatically after merge (check Dependency Dashboard issue updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)