### PR TITLE
fix: switch Renovate to PR-based automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,6 @@
   "dependencyDashboard": true,
   "dependencyDashboardApproval": false,
   "automerge": true,
-  "automergeType": "branch",
-  "platformAutomerge": false
+  "automergeType": "pr",
+  "platformAutomerge": true
 }


### PR DESCRIPTION
## Summary
- Switch `automergeType` from `branch` to `pr`
- Enable `platformAutomerge` so GitHub auto-merges when all checks pass
- Branch automerge doesn't work with rulesets that require PRs

## Test plan
- [ ] Verify Renovate creates PRs with auto-merge enabled after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)